### PR TITLE
Fix a bug in FLAC mimetype handling and add support for OGG Vorbis and Opus files

### DIFF
--- a/get_cover_art/cover_finder.py
+++ b/get_cover_art/cover_finder.py
@@ -5,6 +5,8 @@ from .apple_downloader import AppleDownloader
 from .meta_mp3 import MetaMP3
 from .meta_mp4 import MetaMP4
 from .meta_flac import MetaFLAC
+from .meta_opus import MetaOpus
+from .meta_vorbis import MetaVorbis
 
 DEFAULTS = {
     "cover_art": "_cover_art",
@@ -116,6 +118,10 @@ class CoverFinder(object):
                 meta = MetaMP4(path)
             elif ext == '.flac':
                 meta = MetaFLAC(path)
+            elif ext == '.opus':
+                meta = MetaOpus(path)
+            elif ext == '.ogg':
+                meta = MetaVorbis(path)
             else:
                 self.files_invalid.append(path)
                 return

--- a/get_cover_art/meta_flac.py
+++ b/get_cover_art/meta_flac.py
@@ -27,9 +27,9 @@ class MetaFLAC(MetaAudio):
             pic.data = f.read()
         pic.type = 3 # front cover
         if art_path.endswith('png'):
-            mime = 'image/png'
+            pic.mime = 'image/png'
         else:
-            mime = 'image/jpeg'
+            pic.mime = 'image/jpeg'
         pic.desc = 'front cover'
         self.audio.add_picture(pic)
         self.audio.save()

--- a/get_cover_art/meta_opus.py
+++ b/get_cover_art/meta_opus.py
@@ -1,7 +1,7 @@
 from .meta_audio import MetaAudio
 # It might look odd to be importing from FLAC in the opus
 # metadata encoder, but the VorbisComment spec (used by Opus) 
-# specifies that # it uses the FLAC structure, base64-encoded.
+# specifies that it uses the FLAC structure, base64-encoded.
 from mutagen.flac import Picture
 from mutagen.oggopus import OggOpus
 import base64

--- a/get_cover_art/meta_opus.py
+++ b/get_cover_art/meta_opus.py
@@ -1,0 +1,41 @@
+from .meta_audio import MetaAudio
+# It might look odd to be importing from FLAC in the opus
+# metadata encoder, but the VorbisComment spec (used by Opus) 
+# specifies that # it uses the FLAC structure, base64-encoded.
+from mutagen.flac import Picture
+from mutagen.oggopus import OggOpus
+import base64
+
+class MetaOpus(MetaAudio):
+    def __init__(self, path):
+        self.audio_path = path
+        self.audio = OggOpus(path)
+        try:
+            if 'albumartist' in self.audio:
+                # use Album Artist first
+                self.artist = self.audio['albumartist'][0]
+            else:
+                self.artist = self.audio['artist'][0]
+            self.album = self.audio['album'][0]
+            self.title = self.audio['title'][0]
+        except:
+            raise Exception("missing VorbisComment/opus tags")
+    
+    def has_embedded_art(self):
+        rv = bool(self.audio.get('metadata_block_picture', None))
+        return rv
+
+    def embed_art(self, art_path):
+        artworkfile = open(art_path, 'rb').read()
+        pic = Picture()
+        with open(art_path, "rb") as f:
+            pic.data = f.read()
+        pic.type = 3 # front cover
+        if art_path.endswith('png'):
+            pic.mime = 'image/png'
+        else:
+            pic.mime = 'image/jpeg'
+        pic.desc = 'front cover'
+        self.audio['metadata_block_picture'] = base64.b64encode(pic.write()).decode('utf8')
+        self.audio.save()
+

--- a/get_cover_art/meta_vorbis.py
+++ b/get_cover_art/meta_vorbis.py
@@ -1,7 +1,7 @@
 from .meta_audio import MetaAudio
-# It might look odd to be importing from FLAC in the opus
+# It might look odd to be importing from FLAC in the vorbis
 # metadata encoder, but the VorbisComment spec (used by OGG Vorbis)
-# specifies that # it uses the FLAC structure, base64-encoded.
+# specifies that it uses the FLAC structure, base64-encoded.
 from mutagen.flac import Picture
 from mutagen.oggvorbis import OggVorbis
 import base64

--- a/get_cover_art/meta_vorbis.py
+++ b/get_cover_art/meta_vorbis.py
@@ -1,0 +1,41 @@
+from .meta_audio import MetaAudio
+# It might look odd to be importing from FLAC in the opus
+# metadata encoder, but the VorbisComment spec (used by OGG Vorbis)
+# specifies that # it uses the FLAC structure, base64-encoded.
+from mutagen.flac import Picture
+from mutagen.oggvorbis import OggVorbis
+import base64
+
+class MetaVorbis(MetaAudio):
+    def __init__(self, path):
+        self.audio_path = path
+        self.audio = OggVorbis(path)
+        try:
+            if 'albumartist' in self.audio:
+                # use Album Artist first
+                self.artist = self.audio['albumartist'][0]
+            else:
+                self.artist = self.audio['artist'][0]
+            self.album = self.audio['album'][0]
+            self.title = self.audio['title'][0]
+        except:
+            raise Exception("missing VorbisComment/ogg tags")
+    
+    def has_embedded_art(self):
+        rv = bool(self.audio.get('metadata_block_picture', None))
+        return rv
+
+    def embed_art(self, art_path):
+        artworkfile = open(art_path, 'rb').read()
+        pic = Picture()
+        with open(art_path, "rb") as f:
+            pic.data = f.read()
+        pic.type = 3 # front cover
+        if art_path.endswith('png'):
+            pic.mime = 'image/png'
+        else:
+            pic.mime = 'image/jpeg'
+        pic.desc = 'front cover'
+        self.audio['metadata_block_picture'] = base64.b64encode(pic.write()).decode('utf8')
+        self.audio.save()
+


### PR DESCRIPTION
Hey, here is some code adding support for OGG Vorbis and OGG Opus files (typically found with .ogg and .opus extensions respectively) as well as a minor bug fix for the FLAC support.

I wrote these patches myself and hereby release them and any future merge requests I submit to this repository under the terms of the MIT License currently included as the LICENSE file in the repository.