### PR TITLE
Refactor out the duplicate code used by ogg vorbis/ogg opus into a base ogg class

### DIFF
--- a/get_cover_art/base_ogg.py
+++ b/get_cover_art/base_ogg.py
@@ -1,0 +1,40 @@
+from .meta_audio import MetaAudio
+# It might look odd to be importing from FLAC in the OGG
+# metadata encoder, but the VorbisComment spec (used by OGG formats) 
+# specifies that it uses the FLAC structure, base64-encoded.
+from mutagen.flac import Picture
+import base64
+
+class MetaOgg(MetaAudio):
+    def __init__(self, path):
+        self.audio_path = path
+        self.audio = self.fileparser(path)
+        try:
+            if 'albumartist' in self.audio:
+                # use Album Artist first
+                self.artist = self.audio['albumartist'][0]
+            else:
+                self.artist = self.audio['artist'][0]
+            self.album = self.audio['album'][0]
+            self.title = self.audio['title'][0]
+        except:
+            raise Exception("missing VorbisComment tags (in ogg vorbis or opus file)")
+    
+    def has_embedded_art(self):
+        rv = bool(self.audio.get('metadata_block_picture', None))
+        return rv
+
+    def embed_art(self, art_path):
+        artworkfile = open(art_path, 'rb').read()
+        pic = Picture()
+        with open(art_path, "rb") as f:
+            pic.data = f.read()
+        pic.type = 3 # front cover
+        if art_path.endswith('png'):
+            pic.mime = 'image/png'
+        else:
+            pic.mime = 'image/jpeg'
+        pic.desc = 'front cover'
+        self.audio['metadata_block_picture'] = base64.b64encode(pic.write()).decode('utf8')
+        self.audio.save()
+

--- a/get_cover_art/meta_opus.py
+++ b/get_cover_art/meta_opus.py
@@ -1,41 +1,7 @@
-from .meta_audio import MetaAudio
-# It might look odd to be importing from FLAC in the opus
-# metadata encoder, but the VorbisComment spec (used by Opus) 
-# specifies that it uses the FLAC structure, base64-encoded.
-from mutagen.flac import Picture
 from mutagen.oggopus import OggOpus
-import base64
+from .base_ogg import MetaOgg
 
-class MetaOpus(MetaAudio):
+class MetaOpus(MetaOgg):
     def __init__(self, path):
-        self.audio_path = path
-        self.audio = OggOpus(path)
-        try:
-            if 'albumartist' in self.audio:
-                # use Album Artist first
-                self.artist = self.audio['albumartist'][0]
-            else:
-                self.artist = self.audio['artist'][0]
-            self.album = self.audio['album'][0]
-            self.title = self.audio['title'][0]
-        except:
-            raise Exception("missing VorbisComment/opus tags")
-    
-    def has_embedded_art(self):
-        rv = bool(self.audio.get('metadata_block_picture', None))
-        return rv
-
-    def embed_art(self, art_path):
-        artworkfile = open(art_path, 'rb').read()
-        pic = Picture()
-        with open(art_path, "rb") as f:
-            pic.data = f.read()
-        pic.type = 3 # front cover
-        if art_path.endswith('png'):
-            pic.mime = 'image/png'
-        else:
-            pic.mime = 'image/jpeg'
-        pic.desc = 'front cover'
-        self.audio['metadata_block_picture'] = base64.b64encode(pic.write()).decode('utf8')
-        self.audio.save()
-
+        self.fileparser = OggOpus
+        return MetaOgg.__init__(self, path)

--- a/get_cover_art/meta_vorbis.py
+++ b/get_cover_art/meta_vorbis.py
@@ -1,41 +1,7 @@
-from .meta_audio import MetaAudio
-# It might look odd to be importing from FLAC in the vorbis
-# metadata encoder, but the VorbisComment spec (used by OGG Vorbis)
-# specifies that it uses the FLAC structure, base64-encoded.
-from mutagen.flac import Picture
 from mutagen.oggvorbis import OggVorbis
-import base64
+from .base_ogg import MetaOgg
 
-class MetaVorbis(MetaAudio):
+class MetaVorbis(MetaOgg):
     def __init__(self, path):
-        self.audio_path = path
-        self.audio = OggVorbis(path)
-        try:
-            if 'albumartist' in self.audio:
-                # use Album Artist first
-                self.artist = self.audio['albumartist'][0]
-            else:
-                self.artist = self.audio['artist'][0]
-            self.album = self.audio['album'][0]
-            self.title = self.audio['title'][0]
-        except:
-            raise Exception("missing VorbisComment/ogg tags")
-    
-    def has_embedded_art(self):
-        rv = bool(self.audio.get('metadata_block_picture', None))
-        return rv
-
-    def embed_art(self, art_path):
-        artworkfile = open(art_path, 'rb').read()
-        pic = Picture()
-        with open(art_path, "rb") as f:
-            pic.data = f.read()
-        pic.type = 3 # front cover
-        if art_path.endswith('png'):
-            pic.mime = 'image/png'
-        else:
-            pic.mime = 'image/jpeg'
-        pic.desc = 'front cover'
-        self.audio['metadata_block_picture'] = base64.b64encode(pic.write()).decode('utf8')
-        self.audio.save()
-
+        self.fileparser = OggVorbis
+        return MetaOgg.__init__(self, path)


### PR DESCRIPTION
You're right that duplicating that code is smelly. This pulls out most of the logic into a base ogg class and does minimal setup of the appropriate format parsers in the specific child classes.