### PR TITLE
Discussion: Changes to allow interoperability with other scrapers/decrease network traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ python -m get_cover_art [--path=<path_to_audio_file_or_folder>] [--test] [--othe
                         Filename(s) of folder art to use. Accepts {artist},
                         {album}, and {title} for replacement: e.g. cover.jpg
                         or {album}-{artist}.jpg
-  --output-filename OUTPUT_FILENAME
+  --art-filename ART_FILENAME
                         Name to store downloaded art in, Accepts {artist},
                         {album}, and {title}. Default '{artist} - {album}.jpg'
   --test, --no_embed    scan and download only, don't embed artwork
@@ -87,7 +87,7 @@ can also use bracket formatting with the artist, album, and title fields:
 for instance, --folder-art-name "{artist}-{album}-cover.jpg" would create
 filenames such as "The Beatles-Abbey Road-cover.jpg".
 
-The "--output-filename" option allows you to specify the filename used to
+The "--art-filename" option allows you to specify the filename used to
 store downloaded files, for interoperability with other systems. You __must__
 be careful to avoid collisions between different albums: The default is
 "{artist} - {album}.jpg". If you know that all of the albums you're running
@@ -97,7 +97,7 @@ could use something more generic (such as "cover.jpg").
 _Pro Tip:_ If you have a cover.jpg in each album directory, you can use:
 "--use-folder-art before --folder-art-name cover.jpg --inline"
 and the local images will be used when present (avoiding network lookups).
-You could also specify "--output-filename cover.jpg" if you want to store the
+You could also specify "--art-filename cover.jpg" if you want to store the
 newly downloaded covers in a similar location (again, this is only sane
 in combination with --inline, in cases where each album is stored in 
 a separate directory).

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ python -m get_cover_art [--path=<path_to_audio_file_or_folder>] [--test] [--othe
 
   --path PATH           audio file, or folder of audio files (recursive)
   --dest DEST           destination of artwork
+  --use-folder-art {before,after,none}
+                        Use image from local folder; "before" prevents
+                        downloads, "after" uses as a fallback.
+  --folder-art-name FOLDER_ART_NAME [FOLDER_ART_NAME ...]
+                        Filename(s) of folder art to use. Accepts {artist},
+                        {album}, and {title} for replacement: e.g. cover.jpg
+                        or {album}-{artist}.jpg
+  --output-filename OUTPUT_FILENAME
+                        Name to store downloaded art in, Accepts {artist},
+                        {album}, and {title}. Default '{artist} - {album}.jpg'
   --test, --no_embed    scan and download only, don't embed artwork
   --no_download         embed only previously-downloaded artwork
   --inline              put artwork in same folders as audio files
@@ -61,6 +71,36 @@ python -m get_cover_art [--path=<path_to_audio_file_or_folder>] [--test] [--othe
 if you omit `path`, it will scan the current working directory
 
 _Pro Tip:_ You can run with `--test` first, then browse/prune the downloaded artwork, then run again with `--no_download` to embed only the artwork you didn't prune.
+
+The folder-art options allow you do default to embedding local folder art.
+Some other scraping systems may have created cover art: for instance, some
+Kodi scrapers create a "cover.jpg" image in each album directory.
+
+Specifying "--use-folder-art before" will use these existing images, and only
+download images if there is no existing image. Specifying "--use-folder-art
+after" will attempt to download artwork as usual, only falling back on the
+existing images if the download is unable to locate new art.
+
+The "--folder-art-name" option allows you to specify the filename(s) to use
+for this existing folder art. It defaults to "cover.jpg \_albumcover.jpg folder.jpg", which are 3 filenames commonly used by other scraping programs. You
+can also use bracket formatting with the artist, album, and title fields:
+for instance, --folder-art-name "{artist}-{album}-cover.jpg" would create
+filenames such as "The Beatles-Abbey Road-cover.jpg".
+
+The "--output-filename" option allows you to specify the filename used to
+store downloaded files, for interoperability with other systems. You __must__
+be careful to avoid collisions between different albums: The default is
+"{artist} - {album}.jpg". If you know that all of the albums you're running
+against have their own directories _and_ you are using "--inline", then you
+could use something more generic (such as "cover.jpg").
+
+_Pro Tip:_ If you have a cover.jpg in each album directory, you can use:
+"--use-folder-art before --folder-art-name cover.jpg --inline"
+and the local images will be used when present (avoiding network lookups).
+You could also specify "--output-filename cover.jpg" if you want to store the
+newly downloaded covers in a similar location (again, this is only sane
+in combination with --inline, in cases where each album is stored in 
+a separate directory).
 
 ### From the Python Environment
 ```

--- a/README.md
+++ b/README.md
@@ -44,23 +44,24 @@ python3 -m pip install --upgrade get_cover_art
 python -m get_cover_art [--path=<path_to_audio_file_or_folder>] [--test] [--other options]
 
   --path PATH           audio file, or folder of audio files (recursive)
-  --dest DEST           destination of artwork
-  --use-folder-art {before,after,none}
+  --art-dest DEST       set artwork destination folder
+  --art-dest-inline     set artwork destination folder to same folders as audio files
+  --art-dest-filename ART_DEST_FILENAME
+                        set artwork destination filename format. Accepts {artist},
+                        {album}, and {title}. Default '{artist} - {album}.jpg'
+  --external-art-mode {before,after,none}
                         Use image from local folder; "before" prevents
-                        downloads, "after" uses as a fallback.
-  --folder-art-name FOLDER_ART_NAME [FOLDER_ART_NAME ...]
+                        downloads, "after" uses as a fallback. Default is none.
+  --external-art-filename EXTERNAL_ART_FILENAME [EXTERNAL_ART_FILENAME ...]
                         Filename(s) of folder art to use. Accepts {artist},
                         {album}, and {title} for replacement: e.g. cover.jpg
                         or {album}-{artist}.jpg
-  --art-filename ART_FILENAME
-                        Name to store downloaded art in, Accepts {artist},
-                        {album}, and {title}. Default '{artist} - {album}.jpg'
   --test, --no_embed    scan and download only, don't embed artwork
   --no_download         embed only previously-downloaded artwork
-  --inline              put artwork in same folders as audio files
   --force               overwrite existing artwork
   --verbose             print verbose logging
   --throttle            wait X seconds between downloads
+
   --skip_artists SKIP_ARTISTS
                         file containing artists to skip
   --skip_albums SKIP_ALBUMS
@@ -72,34 +73,34 @@ if you omit `path`, it will scan the current working directory
 
 _Pro Tip:_ You can run with `--test` first, then browse/prune the downloaded artwork, then run again with `--no_download` to embed only the artwork you didn't prune.
 
-The folder-art options allow you do default to embedding local folder art.
+The external-art options allow you to default to embedding local folder art.
 Some other scraping systems may have created cover art: for instance, some
 Kodi scrapers create a "cover.jpg" image in each album directory.
 
-Specifying "--use-folder-art before" will use these existing images, and only
-download images if there is no existing image. Specifying "--use-folder-art
+Specifying "--external-art-mode before" will use these existing images, and only
+download images if there is no existing image. Specifying "--external-art-mode
 after" will attempt to download artwork as usual, only falling back on the
 existing images if the download is unable to locate new art.
 
-The "--folder-art-name" option allows you to specify the filename(s) to use
+The "--external-art-filename" option allows you to specify the filename(s) to use
 for this existing folder art. It defaults to "cover.jpg \_albumcover.jpg folder.jpg", which are 3 filenames commonly used by other scraping programs. You
 can also use bracket formatting with the artist, album, and title fields:
-for instance, --folder-art-name "{artist}-{album}-cover.jpg" would create
+for instance, --external-art-filename "{artist}-{album}-cover.jpg" would create
 filenames such as "The Beatles-Abbey Road-cover.jpg".
 
-The "--art-filename" option allows you to specify the filename used to
+The "--art-dest-filename" option allows you to specify the filename used to
 store downloaded files, for interoperability with other systems. You __must__
 be careful to avoid collisions between different albums: The default is
 "{artist} - {album}.jpg". If you know that all of the albums you're running
-against have their own directories _and_ you are using "--inline", then you
+against have their own directories _and_ you are using "--art-dest-inline", then you
 could use something more generic (such as "cover.jpg").
 
 _Pro Tip:_ If you have a cover.jpg in each album directory, you can use:
-"--use-folder-art before --folder-art-name cover.jpg --inline"
+"--external-art-mode before --external-art-filename cover.jpg --art-dest-inline"
 and the local images will be used when present (avoiding network lookups).
-You could also specify "--art-filename cover.jpg" if you want to store the
+You could also specify "--art-dest-filename cover.jpg" if you want to store the
 newly downloaded covers in a similar location (again, this is only sane
-in combination with --inline, in cases where each album is stored in 
+in combination with --art-dest-inline, in cases where each album is stored in 
 a separate directory).
 
 ### From the Python Environment

--- a/get_cover_art/__main__.py
+++ b/get_cover_art/__main__.py
@@ -9,15 +9,13 @@ from .cover_finder import CoverFinder, DEFAULTS
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--path', help="audio file, or folder of audio files (recursive)", default=".")
-parser.add_argument('--dest', help="destination of artwork", default=DEFAULTS.get('cover_art'))
-
-parser.add_argument('--use-folder-art', choices=['before', 'after', 'none'], default=DEFAULTS.get('use_folder_art'), help='Use image from local folder; "before" prevents downloads, "after" uses as a fallback.')
-parser.add_argument('--folder-art-name', default=DEFAULTS.get('folder_art_name'), help="Filename(s) of folder art to use. Accepts {artist}, {album}, and {title} for replacement: e.g. cover.jpg or {album}-{artist}.jpg", nargs="+")
-parser.add_argument('--art-filename', default=DEFAULTS.get('art_filename'), help="Name to store downloaded art in, Accepts {artist}, {album}, and {title}. Default '{artist} - {album}.jpg'")
-
+parser.add_argument('--art-dest', '--dest', help="set artwork destination folder", default=DEFAULTS.get('cover_art'))
+parser.add_argument('--art-dest-filename', default=DEFAULTS.get('art_dest_filename'), help="set artwork destination filename format. Accepts {artist}, {album}, and {title}. Default '{artist} - {album}.jpg")
+parser.add_argument('--external-art-mode', choices=['before', 'after', 'none'], default=DEFAULTS.get('external_art_mode'), help='Use image from local folder; "before" prevents downloads, "after" uses as a fallback.  Default is none.')
+parser.add_argument('--external-art-filename', default=DEFAULTS.get('external_art_filename'), help="Filename(s) of folder art to use. Accepts {artist}, {album}, and {title} for replacement: e.g. cover.jpg or {album}-{artist}.jpg", nargs="+")
 parser.add_argument('--test', '--no_embed', help="scan and download only, don't embed artwork", action='store_true')
 parser.add_argument('--no_download', help="embed only previously-downloaded artwork", action='store_true')
-parser.add_argument('--inline', help="put artwork in same folders as audio files", action='store_true')
+parser.add_argument('--art-dest-inline', '--inline', help="put artwork in same folders as audio files", action='store_true')
 parser.add_argument('--force', help="overwrite existing artwork", action='store_true')
 parser.add_argument('--verbose', help="print verbose logging", action='store_true')
 parser.add_argument('--throttle', help="number of seconds between queries", default=0)

--- a/get_cover_art/__main__.py
+++ b/get_cover_art/__main__.py
@@ -13,7 +13,7 @@ parser.add_argument('--dest', help="destination of artwork", default=DEFAULTS.ge
 
 parser.add_argument('--use-folder-art', choices=['before', 'after', 'none'], default=DEFAULTS.get('use_folder_art'), help='Use image from local folder; "before" prevents downloads, "after" uses as a fallback.')
 parser.add_argument('--folder-art-name', default=DEFAULTS.get('folder_art_name'), help="Filename(s) of folder art to use. Accepts {artist}, {album}, and {title} for replacement: e.g. cover.jpg or {album}-{artist}.jpg", nargs="+")
-parser.add_argument('--output-filename', default=DEFAULTS.get('output_filename'), help="Name to store downloaded art in, Accepts {artist}, {album}, and {title}. Default '{artist} - {album}.jpg'")
+parser.add_argument('--art-filename', default=DEFAULTS.get('art_filename'), help="Name to store downloaded art in, Accepts {artist}, {album}, and {title}. Default '{artist} - {album}.jpg'")
 
 parser.add_argument('--test', '--no_embed', help="scan and download only, don't embed artwork", action='store_true')
 parser.add_argument('--no_download', help="embed only previously-downloaded artwork", action='store_true')

--- a/get_cover_art/__main__.py
+++ b/get_cover_art/__main__.py
@@ -11,6 +11,10 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--path', help="audio file, or folder of audio files (recursive)", default=".")
 parser.add_argument('--dest', help="destination of artwork", default=DEFAULTS.get('cover_art'))
 
+parser.add_argument('--use-folder-art', choices=['before', 'after', 'none'], default=DEFAULTS.get('use_folder_art'), help='Use image from local folder; "before" prevents downloads, "after" uses as a fallback.')
+parser.add_argument('--folder-art-name', default=DEFAULTS.get('folder_art_name'), help="Filename(s) of folder art to use. Accepts {artist}, {album}, and {title} for replacement: e.g. cover.jpg or {album}-{artist}.jpg", nargs="+")
+parser.add_argument('--output-filename', default=DEFAULTS.get('output_filename'), help="Name to store downloaded art in, Accepts {artist}, {album}, and {title}. Default '{artist} - {album}.jpg'")
+
 parser.add_argument('--test', '--no_embed', help="scan and download only, don't embed artwork", action='store_true')
 parser.add_argument('--no_download', help="embed only previously-downloaded artwork", action='store_true')
 parser.add_argument('--inline', help="put artwork in same folders as audio files", action='store_true')

--- a/get_cover_art/cover_finder.py
+++ b/get_cover_art/cover_finder.py
@@ -54,7 +54,7 @@ class CoverFinder(object):
         self.ignore_artists = ValueStore(options.get('skip_artists', DEFAULTS.get('skip_artists')))
         self.ignore_albums = ValueStore(options.get('skip_albums', DEFAULTS.get('skip_albums')))
         self.ignore_artwork = ValueStore(options.get('skip_artwork', DEFAULTS.get('skip_artwork')))
-        self.output_filename = options.get('output_filename')
+        self.output_filename = options.get('output_filename', DEFAULTS.get('output_filename'))
 
         self.files_processed = [] # artwork was downloaded / embedded
         self.files_skipped = []   # no artwork was available / embeddable

--- a/get_cover_art/cover_finder.py
+++ b/get_cover_art/cover_finder.py
@@ -171,7 +171,7 @@ class CoverFinder(object):
                     local_art = self._find_folder_art(meta, folder)
 
                 # Avoid downloading if it exists and we are in "before" mode
-                if self.downloader and not self.use_folder_art=="before" or not local_art:
+                if self.downloader and (not self.use_folder_art=="before" or not local_art):
                     success = self._download(meta, art_path)
 
                 # Now, if "before" prefer the local art...

--- a/get_cover_art/cover_finder.py
+++ b/get_cover_art/cover_finder.py
@@ -13,6 +13,9 @@ DEFAULTS = {
     "skip_artists": "./skip_artists.txt",
     "skip_albums": "./skip_albums.txt",
     "skip_artwork": "./skip_artwork.txt",
+    "use_folder_art": "none",
+    "folder_art_name": ['cover.jpg', '_albumcover.jpg', 'folder.jpg'],
+    "output_filename": "{artist} - {album}.jpg",
 }
 
 # utility class to cache a set of values
@@ -51,6 +54,7 @@ class CoverFinder(object):
         self.ignore_artists = ValueStore(options.get('skip_artists', DEFAULTS.get('skip_artists')))
         self.ignore_albums = ValueStore(options.get('skip_albums', DEFAULTS.get('skip_albums')))
         self.ignore_artwork = ValueStore(options.get('skip_artwork', DEFAULTS.get('skip_artwork')))
+        self.output_filename = options.get('output_filename')
 
         self.files_processed = [] # artwork was downloaded / embedded
         self.files_skipped = []   # no artwork was available / embeddable
@@ -60,6 +64,8 @@ class CoverFinder(object):
         self.art_folder_override = ""
         self.verbose = options.get('verbose')
         self.downloader = None
+        self.use_folder_art = options.get('use_folder_art', None)
+        self.folder_art_name = options.get('folder_art_name', None)
         if not options.get('no_download'):
             self.downloader = AppleDownloader(self.verbose, float(options.get('throttle') or 0))
         if not options.get('inline'):
@@ -89,12 +95,23 @@ class CoverFinder(object):
         return False
             
     # based on https://stackoverflow.com/questions/295135/turn-a-string-into-a-valid-filename
-    def _slugify(self, value):
+    def _slugify(self, value, has_extension=True):
         """
         Normalizes string, removes non-alpha characters
+
+        This assumes that a filename being passed in has an
+        extension, and preserves the period leading that extension.
+        If you have an extensionless filename, specify has_extension=False
         """
+        if has_extension:
+            value, ext = os.path.splitext(value)
+        else:
+            ext = ""
+
         value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
         value = re.sub('[^\w\s-]', '', bytes.decode(value)).strip()
+
+        value += ext
         
         return value
     
@@ -106,6 +123,14 @@ class CoverFinder(object):
         
         return True
     
+    def _find_folder_art(self, meta, folder):
+        for f in self.folder_art_name:
+            filename = self._slugify(f.format(artist=meta.artist, album=meta.album, title=meta.title), has_extension=True)
+            filename = os.path.join(folder, filename)
+            if os.access(filename, os.R_OK):
+                return filename
+        return None
+
     def scan_file(self, path):
         folder, filename = os.path.split(path)
         base, ext = os.path.splitext(filename.lower())
@@ -127,15 +152,38 @@ class CoverFinder(object):
                 return
             
             if meta:
-                filename = self._slugify("%s - %s" % (meta.artist, meta.album))
-                art_path = os.path.join(art_folder, filename + ".jpg")
+                filename = self._slugify(self.output_filename.format(artist=meta.artist, album=meta.album, title=meta.title))
+                art_path = os.path.join(art_folder, filename)
                 if self._should_skip(meta, art_path, self.verbose):
                     self.files_skipped.append(path)
                     return
 
                 success = True
-                if self.downloader:
-                    success = success and self._download(meta, art_path)
+                # Logic:
+                # If use_folder_art is "before" we want to avoid network 
+                # traffic if possible and use the local file. If 
+                # use_folder_art is "after" then we only use the local
+                # file if the network lookup is unsuccessful.
+                #
+                # First, check if there is a local file (local_art will
+                # be None if not).
+                if self.use_folder_art in ("before", "after"):
+                    local_art = self._find_folder_art(meta, folder)
+
+                # Avoid downloading if it exists and we are in "before" mode
+                if self.downloader and not self.use_folder_art=="before" or not local_art:
+                    success = self._download(meta, art_path)
+
+                # Now, if "before" prefer the local art...
+                if self.use_folder_art == "before":
+                    if local_art:
+                        art_path = local_art
+                # Otherwise, if "after" then only look at the local art if
+                # the download failed (or we were in no-download mode)
+                elif self.use_folder_art == "after" and (not success or not self.downloader):
+                    success = bool(local_art)
+                    art_path = local_art
+
                 if self.embed:
                     success = success and meta.embed(art_path)
                 

--- a/get_cover_art/cover_finder.py
+++ b/get_cover_art/cover_finder.py
@@ -15,7 +15,7 @@ DEFAULTS = {
     "skip_artwork": "./skip_artwork.txt",
     "use_folder_art": "none",
     "folder_art_name": ['cover.jpg', '_albumcover.jpg', 'folder.jpg'],
-    "output_filename": "{artist} - {album}.jpg",
+    "art_filename": "{artist} - {album}.jpg",
 }
 
 # utility class to cache a set of values
@@ -54,7 +54,7 @@ class CoverFinder(object):
         self.ignore_artists = ValueStore(options.get('skip_artists', DEFAULTS.get('skip_artists')))
         self.ignore_albums = ValueStore(options.get('skip_albums', DEFAULTS.get('skip_albums')))
         self.ignore_artwork = ValueStore(options.get('skip_artwork', DEFAULTS.get('skip_artwork')))
-        self.output_filename = options.get('output_filename', DEFAULTS.get('output_filename'))
+        self.art_filename = options.get('art_filename', DEFAULTS.get('art_filename'))
 
         self.files_processed = [] # artwork was downloaded / embedded
         self.files_skipped = []   # no artwork was available / embeddable
@@ -152,7 +152,7 @@ class CoverFinder(object):
                 return
             
             if meta:
-                filename = self._slugify(self.output_filename.format(artist=meta.artist, album=meta.album, title=meta.title))
+                filename = self._slugify(self.art_filename.format(artist=meta.artist, album=meta.album, title=meta.title))
                 art_path = os.path.join(art_folder, filename)
                 if self._should_skip(meta, art_path, self.verbose):
                     self.files_skipped.append(path)


### PR DESCRIPTION
Hey,

These are more involved additions: definitely let me know if you have questions, concerns, or suggestions for a better way to approach this. The default behaviour if the user does not specify any of the new flags should be identical to the old behavior of the program.

These additions are intended to allow get_cover_art to interoperate with other scrapers and use local copies of art when they exist: a lot of setups keep each album in a separate directory, with a "cover.jpg" file in that directory. This branch adds flags that will use that art (embedding it into the media files) if it exists. The user can select whether to use that art if it exists and only do a network lookup if necessary, or to prefer the network lookup and only fall back to the local files if the network is unsuccessful.

The popular Kodi mediaplayer has a number of scrapers that could interact with these additions, for example.

The README.md diff should have detailed info on how this behaves, but I've essentially added the following options:

--use-folder-art : before, after, or none (default none). If it's `none`, local files are ignored (current behavior). If it's `before`, then local files are prefered to avoid network traffic. If it's `after`, local files are used only as fallbacks.

--folder-art-name : A list of one or more filenames to look at locally. Defaults to "cover.jpg _albumcover.jpg folder.jpg", which are 3 filenames used by pretty common scrapers (note that even though there is a default value here, these files are still ignored unless the user specified --use-folder-art of before or after).

There is also a third option, --output-filename, that allows get_cover_art to output cover image files using a particular name. The default is "{artist} - {album}.jpg", which is backward compatible with the old naming scheme. But if a user wants to generate a different name patter (for compatibility with other scraping systems they're using), they can do that here.