### PR TITLE
add option to clear artwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ artwork options:
 behavior options:
   --test, --no_embed    scan and download only, don't embed artwork
   --no_download         embed only previously-downloaded artwork
+  --clear               clear artwork from audio file (regardless of finding art)
   --force               overwrite existing artwork
   --verbose             print verbose logging
   --throttle            wait X seconds between downloads

--- a/get_cover_art/__main__.py
+++ b/get_cover_art/__main__.py
@@ -19,6 +19,7 @@ parser_art.add_argument('--external-art-filename', default=DEFAULTS.get('externa
 
 parser_behavior = parser.add_argument_group('behavior options')
 parser_behavior.add_argument('--test', '--no_embed', help="scan and download only, don't embed artwork", action='store_true')
+parser_behavior.add_argument('--clear', help="clear artwork from audio file (regardless of finding art)", action='store_true')
 parser_behavior.add_argument('--no_download', help="embed only previously-downloaded artwork", action='store_true')
 parser_behavior.add_argument('--force', help="overwrite existing artwork", action='store_true')
 parser_behavior.add_argument('--verbose', help="print verbose logging", action='store_true')

--- a/get_cover_art/base_ogg.py
+++ b/get_cover_art/base_ogg.py
@@ -24,6 +24,9 @@ class MetaOgg(MetaAudio):
         rv = bool(self.audio.get('metadata_block_picture', None))
         return rv
 
+    def detach_art(self):
+        self.audio.pop('metadata_block_picture')
+    
     def embed_art(self, art_path):
         artworkfile = open(art_path, 'rb').read()
         pic = Picture()
@@ -36,5 +39,6 @@ class MetaOgg(MetaAudio):
             pic.mime = 'image/jpeg'
         pic.desc = 'front cover'
         self.audio['metadata_block_picture'] = base64.b64encode(pic.write()).decode('utf8')
-        self.audio.save()
 
+    def save(self):
+        self.audio.save()

--- a/get_cover_art/meta_audio.py
+++ b/get_cover_art/meta_audio.py
@@ -1,17 +1,29 @@
 import os
 
 class MetaAudio(object):    
-    def embed(self, art_path):
+    def embed(self, art_path, detach_existing = True):
         if os.path.exists(art_path):
             print("Embedding art into " + self.audio_path)
+            if detach_existing and self.has_embedded_art():
+                self.detach_art()
             self.embed_art(art_path)
             return True
-        
         return False
+
+    def clear(self):
+        if not self.has_embedded_art():
+            return False
+        self.detach_art()
+        return True
 
     def has_embedded_art(self):
         return False
 
+    def detach_art(self):
+        raise Exception("detach_art called on MetaAudio base class")
+        
     def embed_art(self, art_path):
-        raise Exception("add_art called on MetaAudio base class")
+        raise Exception("embed_art called on MetaAudio base class")
     
+    def save(self):
+        raise Exception("save called on MetaAudio base class")

--- a/get_cover_art/meta_flac.py
+++ b/get_cover_art/meta_flac.py
@@ -19,8 +19,10 @@ class MetaFLAC(MetaAudio):
     def has_embedded_art(self):
         return self.audio.pictures != []
 
-    def embed_art(self, art_path):
+    def detach_art(self):
         self.audio.clear_pictures()
+
+    def embed_art(self, art_path):
         artworkfile = open(art_path, 'rb').read()
         pic = Picture()
         with open(art_path, "rb") as f:
@@ -32,4 +34,6 @@ class MetaFLAC(MetaAudio):
             pic.mime = 'image/jpeg'
         pic.desc = 'front cover'
         self.audio.add_picture(pic)
+
+    def save(self):
         self.audio.save()

--- a/get_cover_art/meta_mp3.py
+++ b/get_cover_art/meta_mp3.py
@@ -22,9 +22,10 @@ class MetaMP3(MetaAudio):
             return True
         return False
 
-    def embed_art(self, art_path):
-        self.audio.tags.delall("APIC") # Delete existing art
+    def detach_art(self):
+        self.audio.tags.delall("APIC")
 
+    def embed_art(self, art_path):
         # from https://stackoverflow.com/questions/409949/how-do-you-embed-album-art-into-an-mp3-using-python
         self.audio.tags.add(
             APIC(
@@ -35,4 +36,6 @@ class MetaMP3(MetaAudio):
                 data=open(art_path, 'rb').read()
             )
         )
+
+    def save(self):
         self.audio.save()

--- a/get_cover_art/meta_mp4.py
+++ b/get_cover_art/meta_mp4.py
@@ -20,9 +20,12 @@ class MetaMP4(MetaAudio):
     def has_embedded_art(self):
         return 'covr' in self.audio.tags
 
+    def detach_art(self):
+        self.audio.tags['covr'] = []
+
     def embed_art(self, art_path):
-        covr = []
         artworkfile = open(art_path, 'rb').read()
-        covr.append(M4ACover(artworkfile, M4ACover.FORMAT_JPEG))
-        self.audio.tags['covr'] = covr
+        self.audio.tags['covr'] = [M4ACover(artworkfile, M4ACover.FORMAT_JPEG)]
+
+    def save(self):
         self.audio.save()


### PR DESCRIPTION
Description:
- Added `--clear` option to clear embedded artwork regardless of downloaded art
- separated detaching / embedding / saving functionality

Testing:
- ran my test suite of example files of each file type, tried embedding as well as clearing