### PR TITLE
Be more explicit in documentation about --external-art-filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ artwork options:
   --external-art-filename EXTERNAL_ART_FILENAME [EXTERNAL_ART_FILENAME ...]
                         Filename(s) of folder art to use. Accepts {artist},
                         {album}, and {title} for replacement: e.g. cover.jpg
-                        or {album}-{artist}.jpg
+                        or {album}-{artist}.jpg ; this does not affect the filename
+                        for art that must be fetched (use --art-dest-filename for
+                        that).
 
 behavior options:
   --test, --no-embed    scan and download only, don't embed artwork

--- a/get_cover_art/__main__.py
+++ b/get_cover_art/__main__.py
@@ -29,7 +29,7 @@ def get_args():
     parser_art.add_argument('--art-dest-inline', '--inline', help="put artwork in same folders as audio files", action='store_true')
     parser_art.add_argument('--art-dest-filename', default=DEFAULTS.get('art_dest_filename'), help="set artwork destination filename format. Accepts {artist}, {album}, and {title}. Default '{artist} - {album}.jpg")
     parser_art.add_argument('--external-art-mode', choices=['before', 'after', 'none'], default=DEFAULTS.get('external_art_mode'), help='Use image from local folder; "before" prevents downloads, "after" uses as a fallback.  Default is none.')
-    parser_art.add_argument('--external-art-filename', default=DEFAULTS.get('external_art_filename'), help="Filename(s) of folder art to use. Accepts {artist}, {album}, and {title} for replacement: e.g. cover.jpg or {album}-{artist}.jpg", nargs="+")
+    parser_art.add_argument('--external-art-filename', default=DEFAULTS.get('external_art_filename'), help="Filename(s) of folder art to use for preexisting external art. Accepts {artist}, {album}, and {title} for replacement: e.g. cover.jpg or {album}-{artist}.jpg ; this does not affect the filename for art that must be fetched (use --art-dest-filename for that).", nargs="+")
 
     parser_behavior = parser.add_argument_group('behavior options')
     parser_behavior.add_argument('--test', '--no-embed', '--no_embed', help="scan and download only, don't embed artwork", action='store_true')


### PR DESCRIPTION
Here's a documentation patch that makes both the `--help` output and README more explicit about `--external-art-filename`'s impact, and points people to `--art-dest-filename`.